### PR TITLE
タスクカードにブランチ名を表示し、GitHubブランチへリンク化

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -49,6 +49,8 @@ export type TaskPrStatus = {
   open_pr_url: string | null;
   latest_pr_status?: 'open' | 'merged' | 'closed' | 'unknown' | null;
   latest_pr_url?: string | null;
+  // Added server field: latest attempt branch (if any)
+  branch?: string | null;
 };
 
 export class ApiError<E = unknown> extends Error {


### PR DESCRIPTION
要望対応: タスクに紐づくブランチ名をカード下部に表示し、クリックで対応するGitHubブランチページを新規タブで開くようにしました。\n\n変更点\n- server: /api/tasks/pr-status のレスポンスに各タスクの最新Attemptブランチ (branch) を追加\n  - 既存のPR情報と同じクエリで取得 (パフォーマンスに影響しない軽量サブクエリ)\n- frontend: TaskCard にブランチ名ピルを追加。PRピルの左側に表示\n  - PR URL からリポジトリURLを推定して  を生成\n  - リポジトリURLが判別できない場合はテキスト表示のみ\n- 型: frontendの TaskPrStatus 型に  を追加\n\n補足\n- 既存の  を流用しているため、追加のAPI呼び出しは不要です。\n- SQLXのオフラインビルド対応のため、このエンドポイントのみ  ではなく  を使用しています。\n\n動作\n- カード下部左側にブランチ名ピルが表示されます。\n- クリックでGitHubの該当ブランチページ (tree/ブランチ) を新規タブで開きます (PR URL からリポジトリを判別できる場合)。\n\nスクリーンショットやスタイル微調整が必要ならお知らせください。